### PR TITLE
don't return an error if redis key does not exist

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -120,10 +120,12 @@ func loadPolicyLine(line CasbinRule, model model.Model) {
 // LoadPolicy loads policy from database.
 func (a *Adapter) LoadPolicy(model model.Model) error {
 	text, err := redis.String(a.conn.Do("GET", a.key))
+	if err == redis.ErrNil {
+		return nil
+	}
 	if err != nil {
 		return err
 	}
-
 	var lines []CasbinRule
 	err = json.Unmarshal([]byte(text), &lines)
 	if err != nil {

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -37,6 +37,12 @@ func TestAdapter(t *testing.T) {
 	e := casbin.NewEnforcer("examples/rbac_model.conf", "examples/rbac_policy.csv")
 
 	a := NewAdapter("tcp", "127.0.0.1:6379")
+	t.Run("Read the policies from an empty redis", func(t *testing.T) {
+		if err := a.LoadPolicy(e.GetModel()); err != nil {
+			t.Error("Should not return an error")
+		}
+	})
+
 	// This is a trick to save the current policy to the DB.
 	// We can't call e.SavePolicy() because the adapter in the enforcer is still the file adapter.
 	// The current policy means the policy in the Casbin enforcer (aka in memory).


### PR DESCRIPTION
Returning an error causes casbin enforcer to panic while loading policies. See [casbin](https://github.com/casbin/casbin/commit/287dc513fa6e1e83f4959b1f4e8eaa8ae3962d7f)