### PR TITLE
#7 Fix incorrect reference in go.mod to a forked repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fengjihua/redis-adapter/v2
+module github.com/casbin/redis-adapter/v2
 
 go 1.12
 


### PR DESCRIPTION
Changed it back to reference github.com/casbin/redis-adapter