### PR TITLE
feat: add TLS option for redis adapter creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ import (
 )
 
 func main() {
+	// Direct Initialization:
 	// Initialize a Redis adapter and use it in a Casbin enforcer:
 	a, _ := redisadapter.NewAdapter("tcp", "127.0.0.1:6379") // Your Redis network and address.
 
@@ -29,6 +30,15 @@ func main() {
 	// Use the following if you use Redis connections pool
 	// pool := &redis.Pool{}
 	// a, err := redisadapter.NewAdapterWithPool(pool)
+	
+	// Initialization with different user options:
+	// Use the following if you use Redis with passowrd like "123":
+	// a, err := redisadapter.NewAdapterWithOption(redisadapter.WithNetwork("tcp"), redisadapter.WithAddress("127.0.0.1:6379"), redisadapter.WithPassword("123"))
+	
+	// Use the following if you use Redis with username, password, and TLS option:
+	// var clientTLSConfig tls.Config
+	// ...
+	// a, err := redisadapter.NewAdapterWithOption(redisadapter.WithNetwork("tcp"), redisadapter.WithAddress("127.0.0.1:6379"), redisadapter.WithUsername("testAccount"), redisadapter.WithPassword("123456"), redisadapter.WithTls(&clientTLSConfig))
 
 	e := casbin.NewEnforcer("examples/rbac_model.conf", a)
 

--- a/adapter.go
+++ b/adapter.go
@@ -151,7 +151,7 @@ func WithKey(key string) Option {
 	}
 }
 
-func WithTLS(tlsConfig *tls.Config) Option {
+func WithTls(tlsConfig *tls.Config) Option {
 	return func(a *Adapter) {
 		a.tlsConfig = tlsConfig
 	}
@@ -159,23 +159,23 @@ func WithTLS(tlsConfig *tls.Config) Option {
 
 func (a *Adapter) open() error {
 	//redis.Dial("tcp", "127.0.0.1:6379")
-	useTLS := a.tlsConfig != nil
+	useTls := a.tlsConfig != nil
 	if a.username != "" {
-		conn, err := redis.Dial(a.network, a.address, redis.DialUsername(a.username), redis.DialPassword(a.password), redis.DialTLSConfig(a.tlsConfig), redis.DialUseTLS(useTLS))
+		conn, err := redis.Dial(a.network, a.address, redis.DialUsername(a.username), redis.DialPassword(a.password), redis.DialTLSConfig(a.tlsConfig), redis.DialUseTLS(useTls))
 		if err != nil {
 			return err
 		}
 
 		a.conn = conn
 	} else if a.password == "" {
-		conn, err := redis.Dial(a.network, a.address, redis.DialTLSConfig(a.tlsConfig), redis.DialUseTLS(useTLS))
+		conn, err := redis.Dial(a.network, a.address, redis.DialTLSConfig(a.tlsConfig), redis.DialUseTLS(useTls))
 		if err != nil {
 			return err
 		}
 
 		a.conn = conn
 	} else {
-		conn, err := redis.Dial(a.network, a.address, redis.DialPassword(a.password), redis.DialTLSConfig(a.tlsConfig), redis.DialUseTLS(useTLS))
+		conn, err := redis.Dial(a.network, a.address, redis.DialPassword(a.password), redis.DialTLSConfig(a.tlsConfig), redis.DialUseTLS(useTls))
 		if err != nil {
 			return err
 		}

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -354,16 +354,13 @@ func arrayEqualsWithoutOrder(a [][]string, b [][]string) bool {
 }
 
 func TestAdapters(t *testing.T) {
-	a, err := NewAdapter("tcp", "127.0.0.1:6379")
+	a, _ := NewAdapter("tcp", "127.0.0.1:6379")
 
 	// Use the following if Redis has password like "123"
 	// a, err := NewAdapterWithPassword("tcp", "127.0.0.1:6379", "123")
 
 	// Use the following if you use Redis with a account
 	// a, err := NewAdapterWithUser("tcp", "127.0.0.1:6379", "testaccount", "userpass")
-	if err != nil {
-		t.Fatal(err)
-	}
 	testSaveLoad(t, a)
 	testAutoSave(t, a)
 	testFilteredPolicy(t, a)
@@ -374,13 +371,11 @@ func TestAdapters(t *testing.T) {
 }
 
 func TestAdapterWithOption(t *testing.T) {
-	a, err := NewAdapterWithOption(WithNetwork("tcp"), WithAddress("127.0.0.1:6379"))
+	a, _ := NewAdapterWithOption(WithNetwork("tcp"), WithAddress("127.0.0.1:6379"))
 	// User the following if use TLS to connect to redis
 	// var clientTLSConfig tls.Config
-	// a, err := NewAdapterWithOption(WithTLS(&clientTLSConfig))
-	if err != nil {
-		t.Fatal(err)
-	}
+	// a, err := NewAdapterWithOption(WithTls(&clientTLSConfig))
+
 	testSaveLoad(t, a)
 	testAutoSave(t, a)
 	testFilteredPolicy(t, a)


### PR DESCRIPTION
Fix: https://github.com/casbin/redis-adapter/issues/36

Use the following if you use Redis with TLS option.


```
var clientTLSConfig tls.Config
...
a, err := NewAdapterWithOption(WithNetwork("tcp"), WithAddress("127.0.0.1:6379"), WithUsername("testAccount"), WithPassword("123456"), WithTLS(&clientTLSConfig))
```