### PR TITLE
feat: fix LoadPolicy() for Amazon MemoryDB for Redis

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -303,7 +303,12 @@ func (a *Adapter) LoadPolicy(model model.Model) error {
 	for _, value := range values {
 		text, ok := value.([]byte)
 		if !ok {
-			return errors.New("the type is wrong")
+			// Amazon MemoryDB for Redis returns string instead of []byte
+			if textStr, ok := value.(string); ok {
+				text = []byte(textStr)
+			} else {
+				return errors.New("the type is wrong")
+			}
 		}
 		err = json.Unmarshal(text, &line)
 		if err != nil {
@@ -545,7 +550,12 @@ func (a *Adapter) loadFilteredPolicy(model model.Model, filter *Filter) error {
 	for _, value := range values {
 		text, ok := value.([]byte)
 		if !ok {
-			return errors.New("the type is wrong")
+			// Amazon MemoryDB for Redis returns string instead of []byte
+			if textStr, ok := value.(string); ok {
+				text = []byte(textStr)
+			} else {
+				return errors.New("the type is wrong")
+			}
 		}
 
 		if !re.Match(text) {


### PR DESCRIPTION
Fix #42 

- Support string type when loading policy, based on the request in #42
- Mock tested locally, **not tested** with real MemoryDB backend.
- No effect to the original logic